### PR TITLE
updated options to support until, utc and output format.

### DIFF
--- a/journalctl.js
+++ b/journalctl.js
@@ -3,6 +3,8 @@ const EventEmitter = require('events');
 const util = require('util');
 const JSONStream = require('./json-stream.js');
 
+const supportedOutputFormats = ['json', 'json-pretty', 'short', 'short-iso', 'short-monotonic', 'verbose', 'export', 'json-sse'];
+
 function Journalctl (opts) {
 	EventEmitter.call(this);
 
@@ -12,8 +14,12 @@ function Journalctl (opts) {
 	if (opts.all) args.push('-a');
 	if (opts.lines) args.push('-n', opts.lines);
 	if (opts.since) args.push('-S', opts.since);
+	if (opts.until) args.push('-U', opts.until);
+	if (opts.reverse) args.push('-r');
+	if (opts.utc) args.push('--utc');
 	if (opts.identifier) args.push('-t', opts.identifier);
 	if (opts.unit) args.push('-u', opts.unit);
+	if (opts.output && supportedOutputFormats.includes(opts.output)) args.push('-o', opts.output);
 	if (opts.filter) {
 		if (!(opts.filter instanceof Array)) opts.filter = [opts.filter];
 		opts.filter.forEach((f) => args.push(f));


### PR DESCRIPTION
Added support for 'until', 'utc', and 'format' options in Journalctl constructor

This commit enhances the Journalctl constructor to include support for the 'until', 'utc', and 'format' options. The 'until' option allows filtering logs until a specific time, while the 'utc' option enables printing timestamps in Coordinated Universal Time (UTC). Additionally, the 'format' option permits specifying the output format.
